### PR TITLE
Fixing XSS for uploaded file with name as xss payload

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.7</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.9</version>
+        </dependency>
         <!-- REDISSON -->
         <dependency>
             <groupId>org.redisson</groupId>

--- a/server/src/main/java/cn/keking/web/controller/FileController.java
+++ b/server/src/main/java/cn/keking/web/controller/FileController.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.*;
 import java.util.*;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  *
@@ -36,6 +37,9 @@ public class FileController {
         // 获取文件名
         String fileName = file.getOriginalFilename();
         //判断是否为IE浏览器的文件名，IE浏览器下文件名会带有盘符信息
+        
+        // escaping dangerous characters to prevent XSS
+        fileName = StringEscapeUtils.escapeHtml4(fileName);
         // Check for Unix-style path
         int unixSep = fileName.lastIndexOf('/');
         // Check for Windows-style path

--- a/server/src/main/resources/web/fileNotSupported.ftl
+++ b/server/src/main/resources/web/fileNotSupported.ftl
@@ -32,7 +32,8 @@
 <div class="container">
     <img src="images/sorry.jpg" />
     <span>
-        该文件类型(${file.suffix})系统暂时不支持在线预览，<b>说明</b>：
+    该文件类型(${file.suffix?html})系统暂时不支持在线预览，<b>说明</b>：      
+    
         <p style="color: red;">${msg}</p>
         有任何疑问，请加&nbsp;<a href="https://jq.qq.com/?_wv=1027&k=5c0UAtu">官方QQ群：613025121</a>&nbsp;咨询
     </span>


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-other-kkfileview

### ⚙️ Description *

During upload of files, all file names characters  that can cause an XSS are transformed in a way the XSS in not possible anymore) preserving the correct view of files name in the web view

### 💻 Technical Description *
The XSS vulnerability has been fixed using an HTML escaping method implemented in the already used apache-common dependencie. The method is "StringEscapeUtils.escapeHtml4(String string)". In a uploaded file, the filename characters are escaped so the attacker can't create the right context for the XSS anymore. This "safe" version of the file name is that one then used by the application. 

### 🐛 Proof of Concept (PoC) *

Uploading a file with this name ("><img src=x onerror=alert(222) ~2F>.xml) a XSS will popup just after upload. 
Being this a stored XSS, this will popup every time the index page in viewed.

![poc_attack](https://user-images.githubusercontent.com/62958189/104777578-2c8e0c00-577c-11eb-85c0-edc3c4627535.png)

### 🔥 Proof of Fix (PoF) *

The short video and the screenshot show that reloading the page with xss payload, the XSS is not fired anymore

The screenshot contains many of the payload I used to test the fix
https://user-images.githubusercontent.com/62958189/104778161-38c69900-577d-11eb-8db0-766f4e629429.mov
<img width="841" alt="Schermata 2021-01-15 alle 21 57 45" src="https://user-images.githubusercontent.com/62958189/104778305-6f041880-577d-11eb-9fd5-f494e6a5bd74.png">



### 👍 User Acceptance Testing (UAT)

After fix the funcionality is still working showing the correct file name and it is not danger anymore. 

